### PR TITLE
docs: 認証フローの明確化（外部アクセストークン前提）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,67 @@
+
+
+## 認証セットアップについて
+
+このActionは、Google Sheets APIへのアクセスにアクセストークンを利用します。呼び出し側のワークフローで `google-github-actions/auth@v2` を実行してアクセストークンを発行し、`GOOGLE_OAUTH_ACCESS_TOKEN`（または `ACCESS_TOKEN`）として本Actionに渡してください。
+
+詳しいセットアップ手順や注意点は、[認証セットアップガイド](docs/setup-oidc.md) をご参照ください。
+
+### クイックスタート（推奨）
+
+1) リポジトリに必要なSecretsを用意
+- `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`
+- `GOOGLE_SERVICE_ACCOUNT`
+- `SPREADSHEET_ID`
+
+2) ワークフローでアクセストークンを発行し、本Actionへ渡す
+
+```yaml
+jobs:
+  sync-spreadsheet:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+  id-token: write  # アクセストークン発行に必要
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          token_format: "access_token"
+          access_token_scopes: "https://www.googleapis.com/auth/spreadsheets"
+
+      - name: Sync spreadsheet to issues
+        uses: tooppoo/spreadsheet-to-issue-action@0.0.1
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          spreadsheet_id: ${{ secrets.SPREADSHEET_ID }}
+          sheet_name: "Sheet1"
+          title_template: "[{{ row.A }}] {{ row.B }}"
+          body_template: "内容: {{ row.C }}\n期限: {{ row.D }}"
+          sync_column: "E"
+```
+
+ヒント:
+- 本Actionは `GOOGLE_OAUTH_ACCESS_TOKEN` を優先し、見つからない場合は `ACCESS_TOKEN` を自動検出します。
+- スコープは Google Sheets への読み書きが必要なため、`https://www.googleapis.com/auth/spreadsheets` を指定してください。
+
+---
+
 ## 概要
 
-Googleスプレッドシートを読み取り、未連携行に対してGitHub Issueを作成します。作成成功時は指定列へ指定の値（既定: TRUE）を書き戻し、重複作成を防ぎます。OIDCを用いたGoogle認証（Workload Identity Federation）で安全に実行します。
+Googleスプレッドシートを読み取り、未連携行に対してGitHub Issueを作成します。作成成功時は指定列へ指定の値（既定: TRUE）を書き戻し、重複作成を防ぎます。Workload Identity Federation（WIF）によるGoogle認証で安全に実行します。
 
 ## 主要機能
 
 - mustacheテンプレートで `{{ row.A }}` のように列参照してタイトル/本文を生成
-- OIDCでGoogle Sheets APIに読み書きアクセス
+- Google Sheets API に読み書きアクセス（アクセストークン利用）
 - 成功時に `sync_column` のセルへ書き戻し値（既定: TRUE）を設定
 - `max_issues_per_run` と `rate_limit_delay` でレート制御
 - 途中失敗は継続し、集計値とURL一覧を出力
@@ -18,28 +74,33 @@ Googleスプレッドシートを読み取り、未連携行に対してGitHub I
 
 ## 入力（Action inputs）
 
-- 必須
-  - `github_token`: Issues作成用トークン（例: `secrets.GITHUB_TOKEN`）
-  - `spreadsheet_id`: SpreadsheetドキュメントID
-  - `sheet_name`: タブ名
-  - `title_template`: mustacheテンプレート
-  - `body_template`: mustacheテンプレート
-  - `sync_column`: 連携済み判定/書き戻し列（例: `"E"`）
-- 任意（既定値）
-  - `labels`（既定: 空文字。JSON配列 or カンマ区切り）
-  - `max_issues_per_run`（既定: 10。0以下やNaNは「無制限」として扱われます）
-  - `rate_limit_delay`（既定: 1000ms）
-  - `read_range`（既定: `A:Z`。列文字で始まるA1範囲のみ対応。例: `A:Z`, `C5:F`。行のみの範囲 `5:10` 等は非対応）
-  - `data_start_row`（既定: 2。1未満の値はエラー。未指定や非数値は2にフォールバック）
-  - `boolean_truthy_values`（既定: `["TRUE","true","True","1","はい","済"]`）
-  - `sync_write_back_value`（既定: `"TRUE"`。シートへ書き戻す値を上書き可能）
-  - `dry_run`（既定: `false`）
+| Name | Required | Default | Description |
+| --- | :--: | --- | --- |
+| `github_token` | Yes | — | GitHub Issues作成用トークン（例: `secrets.GITHUB_TOKEN`） |
+| `spreadsheet_id` | Yes | — | SpreadsheetドキュメントID |
+| `sheet_name` | Yes | — | タブ名 |
+| `title_template` | Yes | — | Issueタイトルのmustacheテンプレート |
+| `body_template` | Yes | — | Issue本文のmustacheテンプレート |
+| `sync_column` | Yes | — | 連携済み判定/書き戻し列（例: `"E"`） |
+| `labels` | No | `""` | 付与ラベル。JSON配列またはカンマ区切り文字列をサポート |
+| `max_issues_per_run` | No | `10` | 1回に作成する最大件数。0以下やNaNは「無制限」として扱われます |
+| `rate_limit_delay` | No | `1000` | 1件ごとの待機ミリ秒 |
+| `read_range` | No | `A:Z` | 列文字で始まるA1範囲のみ対応（例: `A:Z`, `C5:F`）。行のみの範囲（`5:10` 等）は非対応 |
+| `data_start_row` | No | `2` | データ開始行。1未満の値はエラー。未指定や非数値は2にフォールバック |
+| `boolean_truthy_values` | No | `["TRUE","true","True","1","はい","済"]` | 既連携判定のtruthy集合（JSON配列） |
+| `sync_write_back_value` | No | `"TRUE"` | シートへ書き戻す値を上書き可能（例: `"済"`） |
+| `dry_run` | No | `false` | 作成/書戻しを行わずログのみ |
 
 ## 出力（Action outputs）
 
-- `processed_count`, `created_count`, `skipped_count`, `failed_count`
-- `created_issue_urls`（JSON配列。サマリー掲載は最大100件）
-- `summary_markdown`（集計とURL一覧）
+| Name | Description |
+| --- | --- |
+| `processed_count` | 処理行数 |
+| `created_count` | 作成件数 |
+| `skipped_count` | スキップ件数 |
+| `failed_count` | 失敗件数 |
+| `created_issue_urls` | 作成IssueのURL配列（JSON）。サマリー掲載は最大100件 |
+| `summary_markdown` | 集計とURL一覧のサマリーMarkdown |
 
 ## ワークフロー例
 
@@ -50,7 +111,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      id-token: write
+      id-token: write  # アクセストークン発行に必要
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Spreadsheet to Issue Action"
 description: "GoogleスプレッドシートからGitHub Issueを自動作成するComposite Action"
-author: "tooppoo"
+author: "philomagi"
 
 inputs:
   github_token:
@@ -112,7 +112,7 @@ runs:
         DATA_START_ROW: ${{ inputs.data_start_row }}
         BOOLEAN_TRUTHY_VALUES: ${{ inputs.boolean_truthy_values }}
         DRY_RUN: ${{ inputs.dry_run }}
-        # Inherit Google access token from caller's OIDC step
-        GOOGLE_OAUTH_ACCESS_TOKEN: ${{ env.GOOGLE_OAUTH_ACCESS_TOKEN }}
+  # Use Google access token provided by the caller's OIDC step
+  GOOGLE_OAUTH_ACCESS_TOKEN: ${{ env.GOOGLE_OAUTH_ACCESS_TOKEN }}
         # Fallback: also respects ACCESS_TOKEN if provided in the runner env
         ACCESS_TOKEN: ${{ env.ACCESS_TOKEN }}

--- a/docs/setup-oidc.md
+++ b/docs/setup-oidc.md
@@ -1,36 +1,80 @@
 # OIDC認証セットアップ手順（Google Sheets）
 
-このActionは、`google-github-actions/auth@v2` を用いたOIDC認証（Workload Identity Federation）でGoogle Sheets APIにアクセスします。
+このActionは、`google-github-actions/auth@v2` を用いたOIDC（Workload Identity Federation）でGoogle Sheets APIにアクセスします。呼び出し側のワークフローでアクセストークンを発行し、`GOOGLE_OAUTH_ACCESS_TOKEN`（または `ACCESS_TOKEN`）として本Actionに渡してください。
 
 ## 前提
 
 - GCPプロジェクトがあること
 - GitHubリポジトリ/Orgの管理権限があること
 
-## 手順
+## 手順（外部OIDCでアクセストークンを発行）
 
-1. Google Sheets API を有効化
-   - Cloud Console > APIs & Services > Library > Google Sheets API > Enable
+1) Google Sheets API を有効化
+- Cloud Console > APIs & Services > Library > Google Sheets API > Enable
 
-2. サービスアカウント作成
-   - IAM & Admin > Service Accounts > Create
-   - 名前は任意。ロールは不要（後で権限はスプレッドシート側の共有で付与）
+2) サービスアカウント作成
+- IAM & Admin > Service Accounts > Create
+- 名前は任意。ロールは不要（後で権限はスプレッドシート側の共有で付与）
 
-3. Workload Identity Federation（WIF）を設定
-   - IAM & Admin > Workload Identity Federation > Pool作成
-   - ProviderはGitHubを選択 or OIDC Providerを作成し、対象のリポジトリ/Orgに制限
-   - SAへの関連付け（PrincipalをProviderにバインド）を行い、GitHubからのOIDCでそのSAを偽装できるようにする
+3) Workload Identity Federation（WIF）を設定
+- IAM & Admin > Workload Identity Federation > Pool作成
+- ProviderはGitHubを選択 or OIDC Providerを作成し、対象のリポジトリ/Orgに制限
+- サービスアカウント（SA）に対して、作成したProviderからの偽装（impersonation）ができるよう関連付け
 
-4. 対象スプレッドシートをサービスアカウントに共有
-   - スプレッドシートを開き、共有でサービスアカウントのメールを「編集者」として追加
+4) 対象スプレッドシートをサービスアカウントに共有
+- スプレッドシートを開き、共有でサービスアカウントのメールを「編集者」として追加
 
-5. GitHub側の設定
-   - リポジトリのSecretsに以下を追加
-     - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`: 例 `projects/…/locations/global/workloadIdentityPools/…/providers/…`
-     - `GOOGLE_SERVICE_ACCOUNT`: サービスアカウントのメール
-     - `SPREADSHEET_ID`: 対象スプレッドシートのID
-   - ワークフローファイルで `google-github-actions/auth@v2` を呼ぶ際、次を指定
-     - `token_format: 'access_token'`
-     - `access_token_scopes: 'https://www.googleapis.com/auth/spreadsheets'`
+5) GitHub側の設定
+- リポジトリのSecretsに以下を追加
+  - `GOOGLE_WORKLOAD_IDENTITY_PROVIDER`: 例 `projects/.../locations/global/workloadIdentityPools/.../providers/...`
+  - `GOOGLE_SERVICE_ACCOUNT`: サービスアカウントのメール
+  - `SPREADSHEET_ID`: 対象スプレッドシートのID
+
+6) ワークフローの設定
+- ワークフローに以下のpermissionsを付与
+  - `permissions: { contents: read, issues: write, id-token: write }`
+- OIDCでアクセストークンを発行し、本Actionへ渡す
+
+例:
+
+```yaml
+jobs:
+  sync-spreadsheet:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          token_format: 'access_token'
+          access_token_scopes: 'https://www.googleapis.com/auth/spreadsheets'
+
+      - name: Sync spreadsheet to issues
+        uses: tooppoo/spreadsheet-to-issue-action@vX.Y.Z
+        env:
+          GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          spreadsheet_id: ${{ secrets.SPREADSHEET_ID }}
+          sheet_name: 'Sheet1'
+          title_template: '[{{ row.A }}] {{ row.B }}'
+          body_template: |
+            内容: {{ row.C }}
+            期限: {{ row.D }}
+          sync_column: 'E'
+```
+
+注意:
+- `token_format` は `access_token` を指定してください。
+- スコープは `https://www.googleapis.com/auth/spreadsheets` を使用します。
+- 本Actionは `GOOGLE_OAUTH_ACCESS_TOKEN` を優先し、見つからない場合は `ACCESS_TOKEN` を使用します。
 
 参考: https://github.com/google-github-actions/auth


### PR DESCRIPTION
- READMEにクイックスタート追加、入力/出力をテーブル化\n- 内部OIDCの記述を撤去し、外部で発行したアクセストークンを渡す方針に統一\n- docs/setup-oidc.md を外部OIDC手順に一本化\n- action.yml から内部OIDC関連のinputsやステップを削除\n\n動作確認:\n- pnpm install / pnpm build にてビルド成功（型エラーなし）\n\n注意:\n- 既存ワークフローはそのまま動作（呼び出し側でauthし、GOOGLE_OAUTH_ACCESS_TOKENを渡す）